### PR TITLE
include db-specific dependencies from specific var files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     - epel-release
     # - libwmf-devel
     - which
-    - "{{ sql_driver_dependencies }}"
+    - "{{ _sql_driver_dependencies }}"
 
 - name: Ensure Nginx is installed
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: include {{ redmine_sql_driver }}-specific dependencies
+  include_vars: "{{ redmine_sql_driver }}.yml"
+
 # Split playbook with Ruby and Redmmine bug -
 # https://github.com/ansible/ansible/issues/27520
 # TODO: TCP Socket with unicorn
@@ -17,10 +20,10 @@
     - ImageMagick-c++-devel
     - gcc
     - patch
-    - mariadb-devel
     - epel-release
     # - libwmf-devel
     - which
+    - "{{ sql_driver_dependencies }}"
 
 - name: Ensure Nginx is installed
   yum:

--- a/vars/mysql2.yml
+++ b/vars/mysql2.yml
@@ -1,0 +1,2 @@
+sql_driver_dependencies:
+  - mariadb-devel

--- a/vars/mysql2.yml
+++ b/vars/mysql2.yml
@@ -1,2 +1,2 @@
-sql_driver_dependencies:
+_sql_driver_dependencies:
   - mariadb-devel

--- a/vars/postgresql.yml
+++ b/vars/postgresql.yml
@@ -1,2 +1,2 @@
-sql_driver_dependencies:
-  - libpqxx-devel
+_sql_driver_dependencies:
+  - postgresql-devel

--- a/vars/postgresql.yml
+++ b/vars/postgresql.yml
@@ -1,0 +1,2 @@
+sql_driver_dependencies:
+  - libpqxx-devel


### PR DESCRIPTION
- move  hardcoded MariaDB dependency to var file
- add PostgreSQL dependency (libpqxx-devel) to similar var file
- include var file based on _redmine_sql_driver_ variable